### PR TITLE
[KIP-239] EXTCODEHASH opcode for Kaia

### DIFF
--- a/KIPs/kip-239.md
+++ b/KIPs/kip-239.md
@@ -2,7 +2,7 @@
 kip: 239
 title: EXTCODEHASH opcode for Kaia
 author: Lewis (@hyeonLewis)
-discussions-to: TBD
+discussions-to: https://github.com/kaiachain/kips/issues/38
 status: Draft
 type: Core
 created: 2024-12-27

--- a/KIPs/kip-239.md
+++ b/KIPs/kip-239.md
@@ -1,0 +1,71 @@
+---
+kip: 239
+title: EXTCODEHASH opcode for Kaia
+author: Lewis (@hyeonLewis)
+discussions-to: TBD
+status: Draft
+type: Core
+created: 2024-12-27
+---
+
+## Simple Summary
+
+Clarifies and aligns the implementation of `EXTCODEHASH` opcode with [EIP-1052](https://eips.ethereum.org/EIPS/eip-1052) and [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929).
+
+## Abstract
+
+This KIP explains the historical implementation differences of `EXTCODEHASH` in Kaia compared to Ethereum. It also specifies the complete alignment with EIPs starting from the Prague hardfork.
+
+## Motivation
+
+The `EXTCODEHASH` opcode in Kaia has had implementation differences from EIPs. These difference was fixed in the Cancun hardfork but require further alignment, particularly regarding gas costs after the Prague hardfork. This KIP aims to provide clear explanation of the changes and ensure complete compatibility with EIPs.
+
+## Specification
+
+### Parameters
+
+| Parameter         | Value                                                                |
+| ----------------- | -------------------------------------------------------------------- |
+| `ZERO_CODE_HASH`  | `0x0000000000000000000000000000000000000000000000000000000000000000` |
+| `EMPTY_CODE_HASH` | `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` |
+
+### EIP-1052
+
+The `EXTCODEHASH` opcode according to EIP-1052 should return:
+
+- For non-existent accounts: `ZERO_CODE_HASH`
+- For accounts with no code: `EMPTY_CODE_HASH`
+
+In Kaia, the `EXTCODEHASH` opcode returns:
+
+| Hardfork      | Non-existent      | No code           | Note                                                     |
+| ------------- | ----------------- | ----------------- | -------------------------------------------------------- |
+| Before Cancun | `EMPTY_CODE_HASH` | `EMPTY_CODE_HASH` | Wrong EIP-1052 implementation for non-existent accounts. |
+| Cancun        | `ZERO_CODE_HASH`  | `EMPTY_CODE_HASH` | Fully compatible with EIP-1052.                          |
+| Prague        | `ZERO_CODE_HASH`  | `EMPTY_CODE_HASH` |                                                          |
+
+### EIP-2929
+
+The constant gas cost for `EXTCODEHASH` opcode, which is same as `WarmStorageReadCostEIP2929`, should be 100 after the Kore hardfork which introduced EIP-2929.
+
+In Kaia, the `EXTCODEHASH` opcode has the following gas costs:
+
+| Hardfork    | Constant gas cost | Note                                                     |
+| ----------- | ----------------- | -------------------------------------------------------- |
+| Before Kore | 400               | `ExtcodeHashGasConstantinople`                           |
+| Kore        | 100               | Brought EIP-2929.                                        |
+| Cancun      | 400               | Fixed `EXTCODEHASH`, but accidentally shadowed EIP-2929. |
+| Prague      | 100               | Fully compatible with EIP-2929.                          |
+
+## Backwards Compatibility
+
+The fix of gas cost for `EXTCODEHASH` opcode is backwards incompatible since the Prague hardfork. Note that the EIP-1052 implementation was already fixed in the Cancun hardfork.
+
+## References
+
+[EIP-1052](https://eips.ethereum.org/EIPS/eip-1052)
+[EIP-2929](https://eips.ethereum.org/EIPS/eip-2929)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Proposed changes

This KIP clarifies and aligns existing `EXTCODEHASH` opcode in Kaia with Ethereum (EIP-1052, EIP-2929).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] KIP Proposal
- [ ] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you proposed and what alternatives you have considered, etc.