### PR TITLE
Specify the activation of kip-226

### DIFF
--- a/KIPs/kip-226.md
+++ b/KIPs/kip-226.md
@@ -77,7 +77,7 @@ The detailed information of each smart contract is described in the following se
 
 ### Configuration
 
-The KIP-226 shall be activated since the `PRAGUE_FORK_BLOCK_NUMBER`.
+The KIP-226 shall be used since processing `PRAGUE_FORK_BLOCK_NUMBER` block. Please note that the staking information at previous block will be used to process current block since the Kaia hardfork.
 
 | config                     | value |
 | -------------------------- | ----- |
@@ -196,7 +196,7 @@ For both commission types, the following parameters are configurable:
 
 ### Consensus
 
-After the `PRAGUE_FORK_BLOCK_NUMBER`, staked KAIA will be tracked through two mechanisms:
+Since the `PRAGUE_FORK_BLOCK_NUMBER`, staked KAIA will be tracked through two mechanisms:
 
 1. **CnStaking**
 
@@ -232,7 +232,7 @@ The on-chain governance will be maintained except using `StakingTrackerV2` inste
 
 ### `kaia_getStakingInfo`
 
-The new field `clStakingInfo` will be added to the response of `kaia_getStakingInfo` to provide the CLStaking information.
+The new field `clStakingInfo` will be added to the response of `kaia_getStakingInfo` since the `PRAGUE_FORK_BLOCK_NUMBER` to provide the CLStaking information if exists.
 
 - Example
 

--- a/KIPs/kip-226.md
+++ b/KIPs/kip-226.md
@@ -23,6 +23,7 @@ requires: 81, 82
   - [CLDEX](#cldex)
   - [Consensus](#consensus)
   - [On-chain Governance](#on-chain-governance)
+  - [Preparation](#preparation)
 - [JSON-RPC API](#json-rpc-api)
 - [Rationale](#rationale)
 - [Backward Compatibility](#backward-compatibility)
@@ -85,7 +86,7 @@ The KIP-226 shall be used since processing `PRAGUE_FORK_BLOCK_NUMBER` block. Ple
 
 ### CLRegistry
 
-The CLRegistry contract must implement the ICLRegistry interface:
+The `CLRegistry` contract must implement the `ICLRegistry` interface:
 
 ```solidity
 interface ICLRegistry {
@@ -106,6 +107,8 @@ interface ICLRegistry {
 }
 ```
 
+The `CLRegistry` will be registered in [KIP-149](https://kips.kaia.io/KIPs/kip-149) system registry with activation of `PRAGUE_FORK_BLOCK_NUMBER - 1`.
+
 ### StakingTrackerV2
 
 The all external functions of `StakingTrackerV2` contract must have same selector and semantics as the existing `StakingTracker` contract to be compatible with the existing contracts.
@@ -114,6 +117,8 @@ The additional tracking processes of `StakingTrackerV2` are as follows:
 
 1. Creating a new tracker: When creating a new tracker, the `StakingTrackerV2` contract must call `CLRegistry.getAllCLs()` to populate the CL information.
 2. Updating the tracker: When the staked KAIA in `CLPool` changes, the `StakingTrackerV2` contract must update the staked KAIA for the corresponding validator.
+
+The `StakingTrackerV2` will be registered in [KIP-149](https://kips.kaia.io/KIPs/kip-149) system registry with activation of `PRAGUE_FORK_BLOCK_NUMBER`.
 
 #### Voting Power Eligibility
 
@@ -273,6 +278,12 @@ The new field `clStakingInfo` will be added to the response of `kaia_getStakingI
   ```
 
 ## Rationale
+
+### Set activation to `PRAGUE_FORK_BLOCK_NUMBER - 1` for `CLRegistry`
+
+The Kaia's using previous block's staking information to process current block since the Kaia hardfork. It makes the `CLRegistry` at `PRAGUE_FORK_BLOCK_NUMBER - 1` to be required to track the staked KAIA in CLDEX at `PRAGUE_FORK_BLOCK_NUMBER` if exists.
+
+Please note that the `StakingTrackerV2` will also populate the staked KAIA in CLDEX at `PRAGUE_FORK_BLOCK_NUMBER - 1` if transaction creating a new tracker is executed at exact `PRAGUE_FORK_BLOCK_NUMBER - 1` block, which is not feasible.
 
 ### Separate Reward Address
 


### PR DESCRIPTION
## Proposed changes

Current KIP-226 has ambiguous point about the activation of KIP-226. This KIP specifies that KIP-226 will be used since processing prague hardfork, not since the prague hardfork block.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you proposed and what alternatives you have considered, etc.