### PR TITLE
Update KIP-223 with EIP-7623

### DIFF
--- a/KIPs/kip-223.md
+++ b/KIPs/kip-223.md
@@ -6,6 +6,7 @@ discussions-to: https://github.com/kaiachain/kips/issues/22
 status: Draft
 type: Core
 created: 2024-10-18
+updated: 2025-03-05
 ---
 
 ## Abstract

--- a/KIPs/kip-223.md
+++ b/KIPs/kip-223.md
@@ -1,7 +1,7 @@
 ---
 kip: 223
 title: Transaction data gas cost reduction
-author: Lake (@hyunsooda) and Ollie (@blukat29)
+author: Lake (@hyunsooda), Ollie (@blukat29) and Sawyer (@2dvorak)
 discussions-to: https://github.com/kaiachain/kips/issues/22
 status: Draft
 type: Core
@@ -10,46 +10,62 @@ created: 2024-10-18
 
 ## Abstract
 
-Reduce the calldata gas costs to the [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028) level. The purpose is to achieve better compatibility with Ethereum-oriented SDKs and tools.
+Adjust Kaia’s transaction data (calldata) gas cost model to align with [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623), introducing a floor cost for calldata and thereby skipping [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028). By doing so, Kaia can achieve better compatibility with Ethereum’s post-Prague ecosystem and toolchain.
 
 ## Motivation
 
-The adoption of [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028) will improve the compatibility with [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) ecosystem tools.
-Since the introduction of [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337), several bundler software solutions have been developed.
-The bundler's `eth_estimateUserOperationGas` API calculates the gas required for a UserOperation.
-The calculation depends on the calldata costs in a UserOperation.
-The issue is that some tools assumes EIP-2028 rule [unless explicitly configured](https://github.com/eth-infinitism/bundler/blob/f4647969386aa859b7edf608467168d140e5f92c/packages/sdk/src/PreVerificationGasCalculator.ts#L44-L54), making their result incompatible with Kaia.
-This proposal introduces a new hardfork that aligns the calldata cost calculation to that of EIP-2028.
+After Ethereum’s Prague hard fork, which includes [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623), many Ethereum-oriented tools and SDKs assume the updated calldata pricing model.
+If Kaia maintained its previous gas cost rules, developers using Ethereum SDKs or tools (e.g. ERC-4337 bundlers) would encounter mismatches in gas estimates and transaction validity.
+Adopting the [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) calldata pricing model in Kaia eliminates these incompatibilities, allowing seamless use of Ethereum ecosystem software on Kaia.
 
 ## Specification
 
-The gas cost for calldata is determined by the number of non-zero and zero bytes, with each non-zero byte costing 16 gas units and each zero byte costing 4 gas units.
+| Parameter | Value |
+|-|-|
+| `STANDARD_TOKEN_COST` | `4` |
+| `TOTAL_COST_FLOOR_PER_TOKEN` | `10` |
 
-### Overview
+Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
 
-The calldata costs has been depending on the transaction types and hardfork levels.
+Let `isContractCreation` be a boolean indicating the respective event.
 
-Since the genesis block, calldata gas calculation was calculated using the formula:  
-Transaction type 0 (Legacy):
-`nonzero_bytes_in_calldata` * 68 + `zero_bytes_in_calldata` * 4  
-Other types:
-`nonzero_bytes_in_calldata` * 100 + `zero_bytes_in_calldata` * 100
+Let `execution_gas_used` be the gas used for EVM execution with the gas refund subtracted.
 
-Since the Istanbul hardfork, the calculation was simplified to the latter:  
-For all transaction types: `nonzero_bytes_in_calldata` * 100 + `zero_bytes_in_calldata` * 100  
+Let `INITCODE_WORD_COST` be 2 as defined in [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860).
 
-This proposal introduces a new hardfork in which the formula will be:  
-For all transaction types: `nonzero_bytes_in_calldata` * 16 + `zero_bytes_in_calldata` * 4  
-which is identical to [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).
+Let `tx_gas` be the base intrinsic gas for the transaction type (default 21000, additional 10000 for fee-delegated transactions or 15000 for fee-delegation with ratio transactions).
+
+Let `sig_validate_gas` be the gas used for signature validation (gas used to verify signatures for fee-delegated transactions or AccountKey transactions).
+
+```
+tx.gasUsed = (
+    tx_gas
+    + sig_validate_gas 
+    + max(
+        STANDARD_TOKEN_COST * tokens_in_calldata 
+        + execution_gas_used 
+        + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata)),
+        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
+    )
+)
+```
+
+The transaction must pay at minimum `TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` gas for the calldata portion via the floor cost. If the standard cost (including execution) is higher than the floor-based cost, that higher cost applies; otherwise, the floor cost takes precedence, ensuring data-heavy, low-compute transactions pay more.
+
+## Rationale
+
+Because Kaia supports multiple customized transaction formats (e.g., fee-delegated transactions), intrinsic gas is split into `tx_gas` and `sig_validate_gas`. This ensures that gas used for the transaction type and signature validation is calculated separately. As a result, `tx_gas` and `sig_validate_gas` is outside of the maximum function, so that we can apply the floor cost only to the calldata portion.
+
+Other than that, we follow the [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) spec for the calldata gas cost calculation. The numbers in [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) were chosen to reduce the maximum block size while minimizing the impact on regular transactions. However, Kaia does not impose a block gas limit, so that particular rationale does not apply here. Instead, we adopt these parameters primarily for compatibility with Ethereum.
 
 ## Backward Compatibility
 
-The gas pricing change is backwards incompatible since the hardfork.
+The calldata gas repricing is backwards incompatible since the hardfork.
 
-SDKs and Wallets will be able to continue operating with no change as they usually use `eth_estimateGas` API.
+SDKs and Wallets will be able to continue their operations with no change as they usually depend on the estimated gas cost from the `eth_estimateGas` API.
 
 ## References
-[EIP-2028](https://eips.ethereum.org/EIPS/eip-2028)
+[EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)
 
 ## Copyright
 

--- a/KIPs/kip-223.md
+++ b/KIPs/kip-223.md
@@ -1,7 +1,7 @@
 ---
 kip: 223
 title: Transaction data gas cost reduction
-author: Lake (@hyunsooda), Ollie (@blukat29) and Sawyer (@2dvorak)
+author: Lake (@hyunsooda), Ollie (@blukat29), Sawyer (@2dvorak)
 discussions-to: https://github.com/kaiachain/kips/issues/22
 status: Draft
 type: Core


### PR DESCRIPTION
## Proposed changes

- This PR updates KIP-223 to be compliant with [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) instead of [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- None