### PR TITLE
KIP-247: add a block num parameter to swapForGas

### DIFF
--- a/KIPs/kip-247.md
+++ b/KIPs/kip-247.md
@@ -50,7 +50,7 @@ A GaslessApproveTx must meet all the following conditions to be promoted to `txp
 A `GaslessSwapTx` must meet all the following conditions to be inserted to `txpool.queue`:
 
 - S1: `GaslessSwapTx.to` is a whitelisted `GaslessSwapRouter`.
-- S2: `GaslessSwapTx.data` is `swapForGas(token, amountIn, amountOut, amountRepay)`.
+- S2: `GaslessSwapTx.data` is `swapForGas(token, amountIn, amountOut, amountRepay, deadline)`.
 - S3. `token` is a whitelisted ERC20 token.
 
 (Note that above statements can be verified solely through a static validation of a transaction.)
@@ -95,7 +95,7 @@ interface IKIP247 {
         address router;
     }
 
-    function swapForGas(address token, uint256 amountIn, uint256 minAmountOut, uint256 amountRepay) external;
+    function swapForGas(address token, uint256 amountIn, uint256 minAmountOut, uint256 amountRepay, uint256 deadline) external;
     function addToken(address token, address factory, address router) external;
     function removeToken(address token) external;
 


### PR DESCRIPTION
## Proposed changes

I added deadline parameter to `swapForGas()`.

swapForGas uses swapExactTokensForETH internally, but if there is no deadline in the arguments of swapForGas, a fixed value will be passed. This always passes `require(deadline >= block.timestamp, 'UniswapV2Router: EXPIRED');`, so swapForGas requires the user to set the deadline.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [ ] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you proposed and what alternatives you have considered, etc.