### PR TITLE
KIP-247: Add standalone approve

### DIFF
--- a/KIPs/kip-247.md
+++ b/KIPs/kip-247.md
@@ -41,7 +41,7 @@ A GaslessApproveTx must meet all the following conditions to be inserted to `txp
 
 (Note that above statements can be verified solely through a static validation of a transaction.)
 
-A GaslessApproveTx must meet all the following conditions to be promoted to `txpool.pending`:
+A GaslessApproveTx should meet all the following conditions to be promoted to `txpool.pending`:
 
 - AP1: GaslessApproveTx is followed by a GaslessSwapTx of the same sender and the `GaslessSwapTx` can be promoted to `txpool.pending`.
 
@@ -249,6 +249,13 @@ Thus, this KIP proposes the most basic format checks of GaslessTx in transaction
 If many consensus nodes disabled GaslessTx feature, users may experience increased transaction latency.
 However, as long as there are still nodes supporting GaslessTx, the transactions will eventually be executed.
 Also, because this feature is enabled by default, few consensus nodes are expected to disable it.
+
+### Standalone GaslessApproveTx
+
+AP1 may not behave as intended under certain edge conditions.
+However, even in such cases, no risk or negative consequences are introduced.
+The standalone GaslessApproveTx will not be bundled as a gasless transaction, indicating that it will be treated as a regular transaction and will not have impact on system integrity.
+If the sender does not have any KAIA balance, the transaction will not be executed.
 
 ## Backward Compatibility
 

--- a/KIPs/kip-247.md
+++ b/KIPs/kip-247.md
@@ -36,7 +36,7 @@ A GaslessApproveTx must meet all the following conditions to be inserted to `txp
 - A1: `GaslessApproveTx.to` is a whitelisted ERC-20 token.
 - A2: `GaslessApproveTx.data` is `approve(spender, amount)`.
 - A3: `spender` is a whitelisted `GaslessSwapRouter`.
-- A4: `amount` is a nonzero.
+- A4: `amount` is MaxUint.
 - A5: `nonce` is `getNonce(tx.from)`.
 
 (Note that above statements can be verified solely through a static validation of a transaction.)


### PR DESCRIPTION
## Proposed changes

- Add a rationale of standalone approve
- Fix A4 condition: nonzero -> MaxUint
  - some ERC-20 tokens require allowance reset before increasing it, and setting MaxUint allowance removes the motivation to increase the allowance.

## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [ ] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
