### PR TITLE
[KIP-249] Update auction fee vault spec

### DIFF
--- a/KIPs/kip-249.md
+++ b/KIPs/kip-249.md
@@ -65,7 +65,7 @@ Also, during transition to the permissionless network, we’d expect these issue
 | **Searcher**            | A participant who provides a deposit and hidden bid, including the target reference, to the Auctioneer. |
 | **AuctionEntryPoint**   | A contract that handles bid payment, execution of backrun logic, and gas refunds atomically.            |
 | **AuctionDepositVault** | A contract storing each searcher’s deposit, allowing a two-step withdrawal.                             |
-| **AuctionFeeVault**     | A governance-owned contract capturing the bid amounts.                                                  |
+| **AuctionFeeVault**     | A contract capturing and distributing the bid from searcher                                             |
 
 ---
 
@@ -228,11 +228,20 @@ interface IAuctionDepositVault {
     // @dev Deposits KAIA into vault.
     function deposit() external payable;
 
+    // @dev Deposits KAIA for a specific address.
+    function depositFor(address, uint256) external;
+
     // @dev Starts cooldown period to withdraw KAIA.
     function reserveWithdraw() external;
 
     // @dev Withdraws KAIA after cooldown period.
     function withdraw() external;
+
+    // @dev Takes the bid from the searcher.
+    function takeBid(address searcher, uint256 bidAmount) external;
+
+    // @dev Takes the gas fee from the searcher.
+    function takeGasFee(address searcher, uint256 gasAmount) external;
 }
 ```
 
@@ -240,15 +249,51 @@ interface IAuctionDepositVault {
 
 The AuctionFeeVault is a governance-owned smart contract that captures and distributes the bid amounts. After executing each bid, the bidAmount will be sent to AuctionFeeVault.
 
+During the `takeBid` function, the `AuctionFeeVault` will take the bid amount from the searcher and distribute the bid to searcher, proposer according to the each payback rate. The remaining amount will be stored in the `AuctionFeeVault` and can be withdrawn by the owner of the `AuctionFeeVault`.
+
 ```solidity
 interface IAuctionFeeVault {
-    // @dev Receives KAIA
-    receive() payable external;
+    // @dev The maximum payback rate.
+    uint256 public constant MAX_PAYBACK_RATE = 10000; // 100%
 
-    // @dev Distributes the KAIA to multiple receivers.
-    // @dev Please note that this function must be called by governance-owned sender (e.g., KIP-81 Voting contract)
-    function distributeFee(address[] memory, uint256[] amounts) external;
+    // @dev Takes the bid from the searcher.
+    // @dev This function will be called by the AuctionDepositVault.
+    function takeBid(address searcher) external payable;
+
+    // @dev Withdraws the accumulated bid except the payback amount.
+    function withdraw(address to) external;
+
+    // @dev Registers the reward address for the node.
+    // @dev One of the admin registered in the CnStaking contract can update the reward address of the validator.
+    function registerRewardAddress(address nodeId, address rewardAddr) external;
+
+    // @dev Returns the reward address for the node.
+    function getRewardAddr(address nodeId) external view returns (address);
+
+    // @dev Sets the payback rate for the searcher.
+    function setPaybackRate(uint256 _paybackRate) external;
+
+    // @dev Sets the validator payback rate for the validator.
+    function setValidatorPaybackRate(uint256 _validatorPaybackRate) external;
 }
+```
+
+The `registerRewardAddress` function is called by the admin registered in the CnStaking contract.
+
+```solidity
+    /// @dev Register the reward address for a node
+    /// @param nodeId The CN node ID registered as a validator
+    /// @param rewardAddr The reward recipient address
+    function registerRewardAddress(address nodeId, address rewardAddr) external override {
+       /// @dev If there's no corresponding staking contract, it will revert
+       (, address staking, ) = IAddressBook(ADDRESS_BOOK).getCnInfo(nodeId);
+
+       if (!IStaking(staking).isAdmin(msg.sender)) revert OnlyStakingAdmin();
+
+       _nodeIdToRewardAddr[nodeId] = rewardAddr;
+
+       emit RewardAddressRegistered(nodeId, rewardAddr);
+    }
 ```
 
 ---
@@ -267,15 +312,15 @@ The Kaia node exposes the following WebSocket API to deliver live on-chain data 
 
 - `auction_logs`
 
-    - This is the same existing API as `kaia_logs`, but exposed under a different namespace: `auction`
+  - This is the same existing API as `kaia_logs`, but exposed under a different namespace: `auction`
 
 - `auction_newPendingTransactions`
 
-    - This is the same existing API as `kaia_newPendingTransactions`, but exposed under a different namespace: `auction`. Additionally, it adds a new property, `time` field.
+  - This is the same existing API as `kaia_newPendingTransactions`, but exposed under a different namespace: `auction`. Additionally, it adds a new property, `time` field.
 
 - `auction_newHeads`
 
-    - This is the same existing API as `kaia_newHeads`, but exposed under a different namespace: `auction`
+  - This is the same existing API as `kaia_newHeads`, but exposed under a different namespace: `auction`
 
 ---
 


### PR DESCRIPTION
## Proposed changes

This PR updates the AuctionFeeVault spec and its interface. The AuctionFeeVault will now distribute the bid to the searcher and proposer according to each payback rate (10,000 = 100%). This distribution doesn't require additional transactions and is separate from the block reward.

Validators can update their bid recipient address without permission through the admin addresses registered in one of the CnStaking contracts.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you proposed and what alternatives you have considered, etc.