### PR TITLE
[KIP-286] add transition ordering, violation rules

### DIFF
--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -60,6 +60,8 @@ State transitions may occur either **at epoch interval** or **at arbitrary block
 
 Only validators in **ValActive** state participate in consensus and receive rewards. The active validator set consists of the top 50 validators by staking amount at the epoch interval block.
 
+**Suspended Set**: The foundation may suspend validators via `suspendValidator()`, excluding them from the committee without changing their state. A suspended validator stays in its current state (e.g., a suspended `ValActive` validator remains `ValActive`) and continues receiving staking rewards, but does not participate in block production. If all `ValActive` validators are suspended, the suspended set is ignored as a safety fallback to prevent consensus halt.
+
 **Idle Timer**: Validators in `ValInactive` or `ValReady` states are subject to `ValIdleTimeout`. The idle timer accumulates across both states and **only resets when the validator transitions to `Registered` or `ValActive`**. Transitions between `ValInactive` and `ValReady` do not reset the timer. This mechanism prevents a validator from remaining indefinitely in the ValInactive/ValReady states.
 
 ### Registration States
@@ -121,6 +123,7 @@ The `User tx` is a transaction initiated by the user, while `System tx` is a sys
 | ValActive   | ValInactive | Epoch   | Below Top 50 by stake | System tx |
 | ValInactive | ValReady    | Anytime | Over `MinStake`       | User tx   |
 | ValReady    | ValInactive | Anytime | -                     | User tx   |
+| ValReady    | ValInactive | Anytime | Staking amount below `MinStake`                                                                 | System tx |
 | ValReady    | ValInactive | Epoch   | Below Top 50 by stake | System tx |
 | ValReady    | ValActive   | Epoch   | Top 50 by stake       | System tx |
 
@@ -129,7 +132,7 @@ The `User tx` is a transaction initiated by the user, while `System tx` is a sys
 | From      | To          | Timing  | Condition                                                                                     | Trigger   |
 | --------- | ----------- | ------- | --------------------------------------------------------------------------------------------- | --------- |
 | ValActive | ValPaused   | Anytime | `ValPaused count < ValPausedSlotLimit` AND request by self for maintenance                    | User tx   |
-| ValActive | ValPaused   | Anytime | `ValPaused count < ValPausedSlotLimit` AND PFS is less than `PFS_THRESHOLD` (minor violation) | System tx |
+| ValActive | ValPaused   | Anytime | `ValPaused count < ValPausedSlotLimit` AND `ValActive count > minActiveCount` AND PFS is less than `PFS_THRESHOLD` (minor violation) | System tx |
 | ValPaused | ValActive   | Anytime | -                                                                                             | User tx   |
 | ValPaused | ValInactive | Anytime | `paused duration >= ValPausedTimeout`                                                         | System tx |
 | ValPaused | ValInactive | Epoch   | Below Top 50 by stake                                                                         | System tx |
@@ -139,13 +142,24 @@ The `User tx` is a transaction initiated by the user, while `System tx` is a sys
 | From        | To          | Timing  | Condition                                                                                       | Trigger   |
 | ----------- | ----------- | ------- | ----------------------------------------------------------------------------------------------- | --------- |
 | ValActive   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND request by self for offboarding                    | User tx   |
-| ValActive   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND PFS exceeds `PFS_THRESHOLD` (severe violation)     | System tx |
-| ValActive   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND staking amount below `MinStake` (severe violation) | System tx |
+| ValActive   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND `ValActive count > minActiveCount` AND PFS exceeds `PFS_THRESHOLD` (severe violation)     | System tx |
+| ValActive   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND `ValActive count > minActiveCount` AND staking amount below `MinStake` | System tx |
 | ValPaused   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND request by self for offboarding                    | User tx   |
+| ValPaused   | ValExiting  | Anytime | `ValExiting count < ValExitingSlotLimit` AND staking amount below `MinStake`                    | System tx |
 | ValExiting  | ValInactive | Epoch   | -                                                                                               | System tx |
 | ValReady    | Registered  | Anytime | `idle duration >= ValIdleTimeout`                                                               | System tx |
 | ValInactive | Registered  | Anytime | `idle duration >= ValIdleTimeout`                                                               | System tx |
 | ValInactive | Registered  | Anytime | -                                                                                               | User tx   |
+
+### Transition Ordering
+
+System transitions are processed in the following order at every block:
+
+1. **Epoch transition** (epoch blocks only): slot competition, VRank evaluation, candidate promotion
+2. **Violation transition** (every block): MinStake and PFS violations with slot-limited demotions
+3. **Timeout transition** (every block): idle and pause timeout enforcement
+
+This ordering ensures that violation transitions use the post-epoch slot factor for correct slot limit calculations. After an epoch transition changes the active validator count, the new slot factor (`SF = len(ValActive) + len(ValPaused)`) is used to compute `getSlotLimitsFor(SF)` for the subsequent violation checks.
 
 ### Epoch Transition
 
@@ -168,13 +182,15 @@ def process_epoch_transition():
 
     # Build eligible validator pool for top 50 calculation
     # Pool includes: current active, ready, paused validators, and passed candidates
-    # We can assume validators in ValActive have MinStake always since if not, it'll be ValExiting state due to staking violation
-    # Exclude any entity with stake below MinStake
+    # Only entities with stake >= MinStake participate in slot competition
+    # Entities below MinStake are excluded from competition; violation transition handles their demotion
     eligible_pool = [
-        *get_validators_by_state(ValActive),
-        *get_validators_by_state(ValReady),
-        *get_validators_by_state(ValPaused),
-        *passed_candidates
+        v for v in [
+            *get_validators_by_state(ValActive),
+            *get_validators_by_state(ValReady),
+            *get_validators_by_state(ValPaused),
+            *passed_candidates
+        ] if v.stake >= MinStake
     ]
 
     # Determine top 50 by stake (tie-break by address for determinism just in case)
@@ -183,14 +199,14 @@ def process_epoch_transition():
 
     # T3a & T3b: Promote or demote based on top 50
     for entity in eligible_pool:
-        if is_top50(entity, top50):
+        if entity in top50:
             # T3a: Promote to ValActive (entities in top 50)
             if entity.state in (ValReady, CandTesting):
                 transition(entity, ValActive)
             # ValActive stays ValActive
             # ValPaused stays ValPaused (requires voluntary recovery)
         else:
-            # T3b: Demote to ValInactive (entities below top 50)
+            # T3b: Demote to ValInactive (entities below top 50 by slot competition)
             if entity.state in (ValActive, ValPaused, CandTesting, ValReady):
                 transition(entity, ValInactive)
 
@@ -201,9 +217,6 @@ def process_epoch_transition():
         # T4b: Demote to Registered if below MinStake
         else:
             transition(candidate, Registered)
-
-def is_top50(entity, top50):
-    return entity in top50 and entity.stake >= MinStake
 ```
 
 **Ordering Rationale:**
@@ -219,6 +232,62 @@ def is_top50(entity, top50):
 5. **T4a (CandReady → CandTesting)**: Start testing last, after all other transitions are complete, so new testers don't affect the current epoch's calculations.
 
 6. **T4b (CandReady → Registered)**: Demote to Registered if below MinStake.
+
+### Violation Transition
+
+Violation transitions run at every block (after epoch transition if on an epoch block). They handle MinStake and PFS violations with slot-limited demotions. Validators are processed in deterministic address order to ensure consistent results across nodes.
+
+```python
+def process_violation_transition(sorted_validators):
+    # Rule 1: MinStake violation
+    for validator in sorted_validators:
+        if validator.stake >= MinStake:
+            continue
+        if validator.state == ValActive:
+            # ValActive → ValExiting (if slot available and ValActive > minActiveCount)
+            if can_transition(ValExiting):
+                transition(validator, ValExiting)
+        elif validator.state == ValPaused:
+            # ValPaused → ValExiting (if slot available)
+            if count_by_state(ValExiting) < maxSlotAvailable:
+                transition(validator, ValExiting)
+        elif validator.state == ValReady:
+            # ValReady → ValInactive (unconditional, not in active set)
+            transition(validator, ValInactive)
+
+    # Rule 2: PFS violation (only when proposal failure occurred at this block)
+    for validator in sorted_validators:
+        if validator.state != ValActive:
+            continue
+        pfs = get_pfs(validator)
+        if pfs >= PFS_THRESHOLD:
+            # Severe: ValActive → ValExiting
+            if can_transition(ValExiting):
+                transition(validator, ValExiting)
+        elif pfs > 0:
+            # Minor: ValActive → ValPaused
+            if can_transition(ValPaused):
+                transition(validator, ValPaused)
+
+def can_transition(target_state):
+    return count_by_state(target_state) < maxSlotAvailable \
+       and count_by_state(ValActive) > minActiveCount
+```
+
+### Timeout Transition
+
+Timeout transitions run at every block (after violation transition). They enforce idle and pause timeouts.
+
+```python
+def process_timeout_transition(validators):
+    for validator in validators:
+        if validator.state in (ValReady, ValInactive):
+            if idle_duration >= ValIdleTimeout:
+                transition(validator, Registered)
+        elif validator.state == ValPaused:
+            if paused_duration >= ValPausedTimeout:
+                transition(validator, ValInactive)
+```
 
 The following diagram illustrates all valid state transition paths:
 
@@ -259,6 +328,7 @@ flowchart LR
     ValActive -.->|"T3b: below top 50"| ValInactive
     ValInactive -->|"signal ready"| ValReady
     ValReady -->|"cancel ready"| ValInactive
+    ValReady -->|"below MinStake"| ValInactive
     ValReady -.->|"T3b: below top 50"| ValInactive
     ValReady -.->|"T3a: top 50"| ValActive
 
@@ -271,6 +341,7 @@ flowchart LR
 
     %% Exit & Offboarding
     ValPaused -->|"self offboarding"| ValExiting
+    ValPaused -->|"below MinStake"| ValExiting
     ValActive -->|"self offboarding"| ValExiting
     ValActive -->|"severe VRank violation"| ValExiting
     ValExiting -.->|"T1: next epoch"| ValInactive

--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -60,8 +60,6 @@ State transitions may occur either **at epoch interval** or **at arbitrary block
 
 Only validators in **ValActive** state participate in consensus and receive rewards. The active validator set consists of the top 50 validators by staking amount at the epoch interval block.
 
-**Suspended Set**: The foundation may suspend validators via `suspendValidator()`, excluding them from the committee without changing their state. A suspended validator stays in its current state (e.g., a suspended `ValActive` validator remains `ValActive`) and continues receiving staking rewards, but does not participate in block production. If all `ValActive` validators are suspended, the suspended set is ignored as a safety fallback to prevent consensus halt.
-
 **Idle Timer**: Validators in `ValInactive` or `ValReady` states are subject to `ValIdleTimeout`. The idle timer accumulates across both states and **only resets when the validator transitions to `Registered` or `ValActive`**. Transitions between `ValInactive` and `ValReady` do not reset the timer. This mechanism prevents a validator from remaining indefinitely in the ValInactive/ValReady states.
 
 ### Registration States
@@ -120,10 +118,13 @@ The `User tx` is a transaction initiated by the user, while `System tx` is a sys
 
 | From        | To          | Timing  | Condition             | Trigger   |
 | ----------- | ----------- | ------- | --------------------- | --------- |
+| ValActive   | ValInactive | Epoch   | Below `MinStake`      | System tx |
 | ValActive   | ValInactive | Epoch   | Below Top 50 by stake | System tx |
+| ValPaused   | ValInactive | Epoch   | Below `MinStake`      | System tx |
 | ValInactive | ValReady    | Anytime | Over `MinStake`       | User tx   |
 | ValReady    | ValInactive | Anytime | -                     | User tx   |
 | ValReady    | ValInactive | Anytime | Staking amount below `MinStake`                                                                 | System tx |
+| ValReady    | ValInactive | Epoch   | Below `MinStake`      | System tx |
 | ValReady    | ValInactive | Epoch   | Below Top 50 by stake | System tx |
 | ValReady    | ValActive   | Epoch   | Top 50 by stake       | System tx |
 
@@ -180,10 +181,16 @@ def process_epoch_transition():
         else:
             passed_candidates.append(candidate)
 
-    # Build eligible validator pool for top 50 calculation
-    # Pool includes: current active, ready, paused validators, and passed candidates
-    # Only entities with stake >= MinStake participate in slot competition
-    # Entities below MinStake are excluded from competition; violation transition handles their demotion
+    # T3b (below MinStake): demote VA/VR/VP below MinStake directly to ValInactive.
+    # This runs before the top-50 competition so the SF recomputation reflects the correct count.
+    # No slot limit check — unconditional demotion.
+    for validator in [*get_validators_by_state(ValActive), *get_validators_by_state(ValReady), *get_validators_by_state(ValPaused)]:
+        if validator.stake < MinStake:
+            transition(validator, ValInactive)
+
+    # Build eligible validator pool for top 50 calculation.
+    # Pool includes: current active, ready, paused validators (those not just demoted), and passed candidates
+    # with stake >= MinStake.
     eligible_pool = [
         v for v in [
             *get_validators_by_state(ValActive),
@@ -227,7 +234,7 @@ def process_epoch_transition():
 
 3. **T3a (Promote to ValActive)**: Entities in top 50 are promoted. `ValReady` and passed `CandTesting` transition to `ValActive`. `ValPaused` stays paused (recovery is voluntary).
 
-4. **T3b (Demote to ValInactive)**: Entities below top 50 are demoted. `ValActive`, `ValPaused`, `ValReady`, and passed `CandTesting` transition to `ValInactive`.
+4. **T3b (Demote to ValInactive)**: Two cases: (a) `ValActive`, `ValPaused`, `ValReady` below `MinStake` are demoted unconditionally before the top-50 competition; (b) `ValActive`, `ValPaused`, `ValReady`, and passed `CandTesting` that are in the eligible pool but below top 50 are demoted after the competition.
 
 5. **T4a (CandReady → CandTesting)**: Start testing last, after all other transitions are complete, so new testers don't affect the current epoch's calculations.
 
@@ -239,7 +246,8 @@ Violation transitions run at every block (after epoch transition if on an epoch 
 
 ```python
 def process_violation_transition(sorted_validators):
-    # Rule 1: MinStake violation
+    # Rule 1: MinStake violation (non-epoch blocks only).
+    # At epoch blocks, VA/VR/VP below MinStake are already demoted to ValInactive by T3b in process_epoch_transition.
     for validator in sorted_validators:
         if validator.stake >= MinStake:
             continue


### PR DESCRIPTION
## Proposed changes

- **Transition Ordering**: Specify E→V→T order (Epoch → Violation → Timeout) — violation uses post-epoch slot factor
- **Violation Transition**: Add pseudocode for MinStake (ValReady→ValInactive, ValPaused→ValExiting, ValActive→ValExiting) and PFS rules
- **Timeout Transition**: Add pseudocode for idle/pause timeout enforcement
- **Epoch T3b**: Demote VA/VR/VP below MinStake to ValInactive at epoch unconditionally; violation rule1 handles non-epoch blocks only
- **minActiveCount**: Add `ValActive count > minActiveCount` condition to all ValActive demotions — demoting a ValActive reduces consensus participants, so it requires both slot availability and minimum active count protection. ValPaused→ValExiting only checks slot availability since ValPaused is already not in the active set.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- kaiachain/kaia#855 — implementation PR

## Further comments

Changes are consistent with the implementation in kaiachain/kaia#855 (suspended set, E→V→T transition order, I1/I2 separation, epoch T3b for below-MinStake).