### PR TITLE
[KIP-286] rename validator count parameters for semantic clarity

### DIFF
--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -34,9 +34,9 @@ The following parameters are used in this KIP:
 
 | Parameter                | Description                                                                                                                                        | Sample Value                                                  |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `MaxValidatorCount`      | Maximum number of validators across all validator states (ValActive, ValReady, ValInactive, ValPaused, ValExiting)                                 | 100                                                           |
-| `ActiveValidatorCount`   | Number of top-staked validators that is in `ValActive`, `ValPaused` when epoch starts                                                              | 50                                                            |
-| `MaxReadyCandidateCount` | Maximum number of candidates that can be in `CandReady`                                                                                            | 3                                                             |
+| `MaxNodeCount`            | Maximum number of nodes in non-Registered states (CandReady, CandTesting, ValActive, ValReady, ValInactive, ValPaused, ValExiting)                | 100                                                           |
+| `MaxValActivePausedCount` | Maximum allowed number of nodes in `ValActive` or `ValPaused` (used as the epoch slot competition limit)                                          | 50                                                            |
+| `MaxCandReadyCount`       | Maximum number of candidates that can be in `CandReady`                                                                                           | 3                                                             |
 | `MinStake`               | Minimum staking amount required to enter the consensus                                                                                             | 5,000,000 KAIA                                                |
 | `ValPausedTimeout`       | Maximum duration a validator can remain in `ValPaused` before transitioning to `ValInactive`                                                       | 8 hours                                                       |
 | `ValIdleTimeout`         | Maximum duration a validator can remain in `ValInactive` or `ValReady` before transitioning to `Registered`                                        | 30 days                                                       |
@@ -106,7 +106,7 @@ The `User tx` is a transaction initiated by the user, while `System tx` is a sys
 
 | From        | To          | Timing  | Condition                                                                                                                                 | Trigger   |
 | ----------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| Registered  | CandReady   | Anytime | Over `MinStake` AND `CandReady count < MaxReadyCandidateCount` AND `Val* count + CandReady count + CandTesting count < MaxValidatorCount` | User tx   |
+| Registered  | CandReady   | Anytime | Over `MinStake` AND `CandReady count < MaxCandReadyCount` AND `Val* count + CandReady count + CandTesting count < MaxNodeCount` | User tx   |
 | CandReady   | Registered  | Anytime | -                                                                                                                                         | User tx   |
 | CandReady   | Registered  | Epoch   | Below `MinStake`                                                                                                                          | System tx |
 | CandReady   | CandTesting | Epoch   | Over `MinStake`                                                                                                                           | System tx |
@@ -202,7 +202,7 @@ def process_epoch_transition():
 
     # Determine top 50 by stake (tie-break by address for determinism just in case)
     eligible_pool.sort(key=lambda v: (v.stake, v.address), reverse=True)
-    top50 = set(eligible_pool[:ActiveValidatorCount])
+    top50 = set(eligible_pool[:MaxValActivePausedCount])
 
     # T3a & T3b: Promote or demote based on top 50
     for entity in eligible_pool:


### PR DESCRIPTION
## Proposed changes

Rename three parameters for semantic clarity:
- `MaxValidatorCount` → `MaxNodeCount`
- `ActiveValidatorCount` → `MaxValActivePausedCount`
- `MaxReadyCandidateCount` → `MaxCandReadyCount`

Mirrors kaiachain/kaia#865.

## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template
- [x] I have read the CLA and signed by comment
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments