### PR TITLE
[KIP290] Sync IAddressBookV2 interface with kaia#860 and kaia#865

### DIFF
--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -129,7 +129,7 @@ interface IAddressBookV2 {
     event NodeCreated(address indexed nodeId, uint256 gcId);
     event NodeDeleted(address indexed nodeId);
     event SystemTransitionProcessed(address[] nodeIds, State[] newStates);
-    event EpochTransitionProcessed(uint256 epochValCount);
+    event EpochTransitionProcessed(uint256 slotFactor);
 
     // ── User Functions (called by node manager) ──
 
@@ -175,7 +175,8 @@ interface IAddressBookV2 {
 
     /// @notice Batch state transitions computed by the core client
     function processSystemTransition(
-        address[] calldata nodeIds, State[] calldata newStates, uint256[] calldata timeoutAts
+        address[] calldata nodeIds, State[] calldata newStates, uint256[] calldata timeoutAts,
+        uint256 epochSlotFactor
     ) external;
 
     // ── Admin Functions (called by contract owner) ──
@@ -184,8 +185,9 @@ interface IAddressBookV2 {
     function unsuspendValidator(address nodeId) external;
     function updatePauseTimeout(uint256 newPauseTimeout) external;
     function updateIdleTimeout(uint256 newIdleTimeout) external;
-    function updateMaxValidatorCount(uint256 newMaxValidatorCount) external;
-    function updateMaxReadyCandidateCount(uint256 newMaxReadyCandidateCount) external;
+    function updateMaxNodeCount(uint256 newMaxNodeCount) external;
+    function updateMaxValActivePausedCount(uint256 newMaxValActivePausedCount) external;
+    function updateMaxCandReadyCount(uint256 newMaxCandReadyCount) external;
     function updatePfsThreshold(uint256 newPfsThreshold) external;
     function updateCfsThreshold(uint256 newCfsThreshold) external;
 
@@ -203,7 +205,8 @@ interface IAddressBookV2 {
     function epochBlockInterval() external view returns (uint256);
     function currentEpoch() external view returns (uint256);
     function getTimeouts() external view returns (uint256 pauseTimeout, uint256 idleTimeout);
-    function getMaxCounts() external view returns (uint256 maxValidatorCount, uint256 maxReadyCandidateCount);
+    function getMaxCounts() external view returns (uint256 maxNodeCount, uint256 maxCandReadyCount);
+    function getMaxValActivePausedCount() external view returns (uint256);
     function getPfsThreshold() external view returns (uint256);
     function getCfsThreshold() external view returns (uint256);
 }

--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -201,7 +201,9 @@ interface IAddressBookV2 {
     function getStateCount(State state) external view returns (uint256);
     function getSlotFactor() external view returns (uint256);
     function getSlotLimits() external view returns (uint256 maxSlot, uint256 minActive);
+    function getSlotLimitsFor(uint256 sf) external pure returns (uint256 maxSlot, uint256 minActive);
     function getRegisteredNodes() external view returns (address[] memory);
+    function getSuspendedValidators() external view returns (address[] memory);
     function epochBlockInterval() external view returns (uint256);
     function currentEpoch() external view returns (uint256);
     function getTimeouts() external view returns (uint256 pauseTimeout, uint256 idleTimeout);


### PR DESCRIPTION
## Proposed changes

Sync `IAddressBookV2` interface in KIP-290 with kaiachain/kaia#855, kaiachain/kaia#860, and kaiachain/kaia#865.

## Types of changes

- [ ] Bugfix
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- kaiachain/kaia#855
- kaiachain/kaia#860
- kaiachain/kaia#865

## Further comments

The implementation in kaiachain/system-contracts has already been updated in [PR #154](https://github.com/kaiachain/system-contracts/pull/154).