### PR TITLE
[KIP-286] Clarify VRankEpoch alignment consequences

### DIFF
--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -47,7 +47,7 @@ The following parameters are used in this KIP:
 | `PFS_THRESHOLD`          | Threshold for proposal failure score (PFS) per epoch. PFS ≥ PFS_THRESHOLD indicates severe violation (defined in [KIP-227](./kip-227.md))          | 2                                                             |
 | `CFS_THRESHOLD`          | Threshold for candidate failure score during VRank testing. CFS ≥ CFS_THRESHOLD indicates failing the testing (defined in [KIP-227](./kip-227.md)) | 300                                                           |
 
-> **Note**: The permissionless hardfork block number MUST be a multiple of `VRankEpoch` to ensure VRank scoring starts cleanly at an epoch boundary.
+> **Note**: The permissionless hardfork block number MUST be a multiple of `VRankEpoch`. Otherwise the first post-fork epoch cannot accumulate scores over a full `VRankEpoch` window, and any query into the pre-fork portion of that epoch has no VRank data to return.
 
 ### Overview
 


### PR DESCRIPTION
## Proposed changes

- **Expand VRankEpoch alignment Note**: append the consequence of violating the rule — the first post-fork epoch cannot accumulate scores over a full `VRankEpoch` window, and any query into the pre-fork portion has no VRank data to return.

## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- N/A

## Further comments

The existing Note stated the rule but not the reason, making the constraint look arbitrary. This PR adds the consequence so the rule has a visible rationale.
