### PR TITLE
KIP-290: add node metadata JSON schema

### DIFF
--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -118,21 +118,27 @@ enum State {
 
 The `metadata` field in `NodeInfo` is a JSON-encoded string. All fields are optional. Unrecognized fields SHOULD be ignored by readers.
 
-| Field         | Type             | Description                        |
-| ------------- | ---------------- | ---------------------------------- |
-| `name`        | string           | Human-readable node operator name  |
-| `description` | string           | Free-form description of the node  |
-| `tags`        | array of strings | Descriptive labels for the node    |
-| `websites`    | array of strings | URLs associated with the operator  |
+| Field         | Type     | Description                        |
+| ------------- | -------- | ---------------------------------- |
+| `name`        | string   | Human-readable node operator name  |
+| `thumbnail`   | string   | URL to operator thumbnail/logo     |
+| `summary`     | string   | Short description                  |
+| `description` | string   | Long description                   |
+| `categories`  | string[] | Categorization labels              |
+| `websites`    | string[] | URLs associated with the operator  |
+| `communities` | string[] | Community/social links             |
 
 Example:
 
 ```json
 {
     "name": "Kaia Foundation",
-    "tags": ["foundation", "layer1", "asia"],
+    "thumbnail": "https://cdn.prod.website-files.com/66a8ba5239a3fbe8e678da2a/69866193d03bf54b81aa0283_66ce395e60f880698890073dcc91fa28_kaia-logo.svg",
+    "summary": "The organization behind the Kaia blockchain.",
+    "description": "The Kaia Foundation is the organization behind the Kaia blockchain, an EVM-compatible Layer 1 built for stablecoin settlement and onchain finance across Asia.",
+    "categories": ["foundation", "layer1", "asia"],
     "websites": ["https://kaia.io", "https://docs.kaia.io", "https://portal.kaia.io"],
-    "description": "The Kaia Foundation is the organization behind the Kaia blockchain, an EVM-compatible Layer 1 built for stablecoin settlement and onchain finance across Asia."
+    "communities": ["https://x.com/KaiaChain", "https://blog.kaia.io"]
 }
 ```
 

--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -114,6 +114,28 @@ enum State {
 
 > **Note**: `nodeId` is used as the mapping key in AddressBookV2 and is not stored inside the `NodeInfo` struct. The `timeoutAt` field records the expiry timestamp for `ValPaused` (pause timeout) and `ValInactive`/`ValReady` (idle timeout) states; it is 0 when no timeout is active.
 
+#### Node Metadata Schema
+
+The `metadata` field in `NodeInfo` is a JSON-encoded string. All fields are optional. Unrecognized fields SHOULD be ignored by readers.
+
+| Field         | Type             | Description                        |
+| ------------- | ---------------- | ---------------------------------- |
+| `name`        | string           | Human-readable node operator name  |
+| `description` | string           | Free-form description of the node  |
+| `tags`        | array of strings | Descriptive labels for the node    |
+| `websites`    | array of strings | URLs associated with the operator  |
+
+Example:
+
+```json
+{
+    "name": "Kaia Foundation",
+    "tags": ["foundation", "layer1", "asia"],
+    "websites": ["https://kaia.io", "https://docs.kaia.io", "https://portal.kaia.io"],
+    "description": "The Kaia Foundation is the organization behind the Kaia blockchain, an EVM-compatible Layer 1 built for stablecoin settlement and onchain finance across Asia."
+}
+```
+
 #### Interface
 
 AddressBookV2 replaces the existing AddressBook at `0x0000000000000000000000000000000000000400` starting from `FORK_BLOCK`. The interface is divided into user functions (called by node manager), system functions (called by core client via system transaction following [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) convention), and admin functions (called by contract owner).


### PR DESCRIPTION
## Proposed changes

Add node metadata JSON schema to KIP-290. The `metadata` field in `NodeInfo` is a JSON-encoded string storing optional operator information (name, description, tags, websites).

## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
