### PR TITLE
KIP-227/286/290: sync permissionless implementation

### DIFF
--- a/KIPs/kip-227.md
+++ b/KIPs/kip-227.md
@@ -150,10 +150,13 @@ VRank runs in parallel with consensus. Per block, reports (`pfReport` and `cfRep
 
 #### Block Validation
 
+Before `FORK_BLOCK`, `header.VRank` MUST be empty (zero-length bytes).
+
 After `FORK_BLOCK`, validators MUST validate `header.VRank` per the encoding table in [Block Header Extension (VRank)](#block-header-extension-vrank), and additionally:
 
-- At epoch-start (`N % EPOCH_LENGTH == 0`), the decoded list MUST equal `CandTesting(N)` resolved at block `N`, with no duplicates.
-- Otherwise, `cfReport(N)` MUST contain at most one entry per candidate ID, and each entry MUST be a candidate address from `candidates(N-1)`.
+- At epoch-start (`N % EPOCH_LENGTH == 0`), the decoded list MUST exactly equal `CandTesting(N)` resolved at block `N` (preserving the order returned by the valset module, with no duplicates).
+- At a non-epoch block with a non-empty payload, `cfReport(N)` MUST be sorted in ascending byte order, contain at most one entry per candidate ID, and each entry MUST be a candidate address from `candidates(N-1)`.
+- At a non-epoch block, an empty payload (`nil` or zero-length) is permitted and represents no candidate failures for that block.
 
 ### Failure Scores (PFS, CFS)
 

--- a/KIPs/kip-227.md
+++ b/KIPs/kip-227.md
@@ -147,6 +147,7 @@ VRank runs in parallel with consensus. Per block, reports (`pfReport` and `cfRep
 1. The proposer MUST set `header.VRank` per the encoding table in [Block Header Extension (VRank)](#block-header-extension-vrank).
 2. `cfReport(N+1)` MUST include each candidate (in `CandTesting` at block `N`) who either (a) did not send a `VRankCandidate` for block `N` on-time, or (b) sent an invalid message (including ECDSA or BLS signature failure, or a missing KIP-113 BLS key registration).
 3. Candidates in `cfReport` are counted as failures for CFS aggregation. The epoch-start candidate list is informational only and does not contribute to CFS.
+4. If block `N+1` is an epoch-start block (`(N+1) % EPOCH_LENGTH == 0`), the proposer MUST NOT include a `cfReport` for block `N`; instead, `header(N+1).VRank` carries `CandTesting(N+1)` as specified in the encoding table.
 
 #### Block Validation
 
@@ -155,7 +156,7 @@ Before `FORK_BLOCK`, `header.VRank` MUST be empty (zero-length bytes).
 After `FORK_BLOCK`, validators MUST validate `header.VRank` per the encoding table in [Block Header Extension (VRank)](#block-header-extension-vrank), and additionally:
 
 - At epoch-start (`N % EPOCH_LENGTH == 0`), the decoded list MUST exactly equal `CandTesting(N)` resolved at block `N` (preserving the order returned by the valset module, with no duplicates).
-- At a non-epoch block with a non-empty payload, `cfReport(N)` MUST be sorted in ascending byte order, contain at most one entry per candidate ID, and each entry MUST be a candidate address from `candidates(N-1)`.
+- At a non-epoch block with a non-empty payload, `cfReport(N)` MUST be sorted in ascending byte order, contain at most one entry per candidate ID, and each entry MUST be a candidate address from `CandTesting(N-1)`.
 - At a non-epoch block, an empty payload (`nil` or zero-length) is permitted and represents no candidate failures for that block.
 
 ### Failure Scores (PFS, CFS)

--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -102,6 +102,16 @@ After `FORK_BLOCK`, the following consensus rules apply based on the qualified s
 3. **Committed seals**: Seal verification MUST use `qualified(N)` as the signer set (not the full council). A seal from a non-qualified validator MUST be rejected.
 4. **Quorum**: The quorum threshold is computed from `len(qualified(N))`. The `istanbul.committeesize` governance parameter is ignored after `FORK_BLOCK`.
 
+### Governance Parameter Deprecation
+
+After `FORK_BLOCK`, the following governance parameters are deprecated and MUST be rejected for voting:
+
+| Parameter | Reason |
+| --------- | ------ |
+| `governance.addvalidator` | Validator membership is governed by AddressBookV2 state transitions (see [KIP-290](./kip-290.md)) |
+| `governance.removevalidator` | Validator membership is governed by AddressBookV2 state transitions (see [KIP-290](./kip-290.md)) |
+| `istanbul.committeesize` | The committee is derived from the qualified validator set; a fixed size parameter is no longer applicable |
+
 ### Derived Node Sets
 
 The following node sets are derived from validator states at a given block number `N`. They are used by the core client for consensus, networking, and governance.

--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -102,6 +102,21 @@ After `FORK_BLOCK`, the following consensus rules apply based on the qualified s
 3. **Committed seals**: Seal verification MUST use `qualified(N)` as the signer set (not the full council). A seal from a non-qualified validator MUST be rejected.
 4. **Quorum**: The quorum threshold is computed from `len(qualified(N))`. The `istanbul.committeesize` governance parameter is ignored after `FORK_BLOCK`.
 
+### Derived Node Sets
+
+The following node sets are derived from validator states at a given block number `N`. They are used by the core client for consensus, networking, and governance.
+
+| Set | Definition | Description |
+| --- | ---------- | ----------- |
+| **Council** | `{ValActive, ValPaused}` | Nodes committed to the Istanbul consensus cycle. `ValReady` is excluded — it is a voluntary standby, not a consensus commitment. |
+| **Committee** | `{ValActive} - {Suspended}` | Nodes eligible for consensus signing and block proposing. Identical to the qualified validator set. |
+| **HeaderGovVoters** | `{ValActive} - {Suspended}` | Nodes eligible to cast governance votes in block headers. Same membership as Committee. |
+| **CNPeers** | `{ValActive, ValReady, ValPaused, CandReady, CandTesting}` | Nodes that SHOULD maintain CN-CN P2P connections. `CandReady` is included so that P2P connectivity is established before `CandTesting` promotion. |
+| **RewardEligible** | `{ValActive}` | Nodes eligible to receive block rewards. |
+| **EpochCompetitors** | `{ValActive, ValReady, ValPaused, CandTesting}` | Nodes that enter the top-50 stake competition at epoch transition (see [Epoch Transition](#epoch-transition)). |
+
+> **Note**: Only **Council** and **Committee** are exposed as external APIs. All other sets are internal to the core client and SHOULD NOT be relied upon by external consumers.
+
 ### State Transitions
 
 State transitions are categorized by timing:

--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -79,11 +79,28 @@ Only validators in **ValActive** state participate in consensus and receive rewa
 
 | State       | Description                                                                                                         |
 | ----------- | ------------------------------------------------------------------------------------------------------------------- |
-| ValActive   | Active validator participating in consensus and earning rewards (= committee). Must be in top 50 by staking amount. |
+| ValActive   | Active validator that has earned a top-50 position. Participates in consensus and earns rewards unless suspended. Must be in top 50 by staking amount. |
 | ValReady    | Validator has signaled readiness to become `ValActive`. Waiting for top 50 position.                                |
 | ValInactive | Inactive validator not participating in consensus. Need to signal readiness or exit to avoid timeout.               |
 | ValPaused   | Validator in maintenance/recovery mode. May be voluntary or forced by VRank violation.                              |
 | ValExiting  | Transitional state for current epoch. Becomes `ValInactive` at next epoch.                                          |
+
+### Qualified Validators
+
+The **qualified validator set** (also referred to as the **committee**) is the set of validators that participate in consensus and are eligible to produce and verify blocks at a given block number:
+
+```
+qualified(N) = {ValActive at N} - {Suspended at N}
+```
+
+If the entire `ValActive` set is suspended (safety fallback), `qualified(N)` falls back to all `ValActive` validators.
+
+After `FORK_BLOCK`, the following consensus rules apply based on the qualified set:
+
+1. **header.Extra validators**: The validators encoded in `header.Extra` MUST exactly equal `qualified(N)`.
+2. **Block author**: The block author (proposer) MUST equal `GetProposer(N, round)` where `round` is derived from `header.Extra`. Blocks from unauthorized proposers MUST be rejected.
+3. **Committed seals**: Seal verification MUST use `qualified(N)` as the signer set (not the full council). A seal from a non-qualified validator MUST be rejected.
+4. **Quorum**: The quorum threshold is computed from `len(qualified(N))`. The `istanbul.committeesize` governance parameter is ignored after `FORK_BLOCK`.
 
 ### State Transitions
 

--- a/KIPs/kip-286.md
+++ b/KIPs/kip-286.md
@@ -169,44 +169,47 @@ Epoch transitions occur at the start of the first block of the next epoch (`bloc
 
 ```python
 def process_epoch_transition():
-    # T1: Clear transitional states
-    for validator in get_validators_by_state(ValExiting):
-        transition(validator, ValInactive)
+    # T1, T2, T4, and the eligible-pool collection all run in a single pass
+    # over all entities. T1 and T4 do not contribute competitors.
+    # T3b (MinStake) and pool building are handled inline via compete_or_demote.
+    competitors = []
 
-    # T2: Evaluate VRank for candidates in testing
-    # Failed candidates return to Registered, passed candidates are marked for promotion
-    passed_candidates = []
-    for candidate in get_candidates_by_state(CandTesting):
-        if not passed_vrank(candidate):
-            transition(candidate, Registered)
+    def compete_or_demote(entity):
+        # T3b (below MinStake): demote directly to ValInactive, no slot check.
+        # Otherwise add to the top-50 competition pool.
+        if entity.stake >= MinStake:
+            competitors.append(entity)
         else:
-            passed_candidates.append(candidate)
+            transition(entity, ValInactive)
 
-    # T3b (below MinStake): demote VA/VR/VP below MinStake directly to ValInactive.
-    # This runs before the top-50 competition so the epochVACount recomputation reflects the correct count.
-    # No slot limit check — unconditional demotion.
-    for validator in [*get_validators_by_state(ValActive), *get_validators_by_state(ValReady), *get_validators_by_state(ValPaused)]:
-        if validator.stake < MinStake:
-            transition(validator, ValInactive)
+    for entity in get_all_entities():
+        if entity.state == ValExiting:
+            transition(entity, ValInactive)          # T1
 
-    # Build eligible validator pool for top 50 calculation.
-    # Pool includes: current active, ready, paused validators (those not just demoted), and passed candidates
-    # with stake >= MinStake.
-    eligible_pool = [
-        v for v in [
-            *get_validators_by_state(ValActive),
-            *get_validators_by_state(ValReady),
-            *get_validators_by_state(ValPaused),
-            *passed_candidates
-        ] if v.stake >= MinStake
-    ]
+        elif entity.state == CandReady:
+            # T4: processed here, before top-50 sorting.
+            # Newly promoted CandTesting nodes don't enter this epoch's pool;
+            # they begin VRank evaluation and may compete starting next epoch.
+            if entity.stake >= MinStake:
+                transition(entity, CandTesting)      # T4a
+            else:
+                transition(entity, Registered)       # T4b
 
-    # Determine top 50 by stake (tie-break by address for determinism just in case)
-    eligible_pool.sort(key=lambda v: (v.stake, v.address), reverse=True)
-    top50 = set(eligible_pool[:MaxValActivePausedCount])
+        elif entity.state == CandTesting:
+            if not passed_vrank(entity):
+                transition(entity, Registered)       # T2: fail
+            else:
+                compete_or_demote(entity)            # T2: pass → enter pool
+
+        elif entity.state in (ValActive, ValReady, ValPaused):
+            compete_or_demote(entity)
+
+    # Determine top 50 by stake (tie-break by address for determinism)
+    competitors.sort(key=lambda v: (v.stake, v.address), reverse=True)
+    top50 = set(competitors[:MaxValActivePausedCount])
 
     # T3a & T3b: Promote or demote based on top 50
-    for entity in eligible_pool:
+    for entity in competitors:
         if entity in top50:
             # T3a: Promote to ValActive (entities in top 50)
             if entity.state in (ValReady, CandTesting):
@@ -215,31 +218,24 @@ def process_epoch_transition():
             # ValPaused stays ValPaused (requires voluntary recovery)
         else:
             # T3b: Demote to ValInactive (entities below top 50 by slot competition)
-            if entity.state in (ValActive, ValPaused, CandTesting, ValReady):
-                transition(entity, ValInactive)
-
-    for candidate in get_candidates_by_state(CandReady):
-        # T4a: Start new testing period for ready candidates
-        if candidate.stake >= MinStake:
-            transition(candidate, CandTesting)
-        # T4b: Demote to Registered if below MinStake
-        else:
-            transition(candidate, Registered)
+            transition(entity, ValInactive)
 ```
 
 **Ordering Rationale:**
 
+T1, T4, T2, and the eligible-pool collection (T3b MinStake check) are processed in a single pass over all entities. The top-50 sort and T3a/T3b competition follow.
+
 1. **T1 (ValExiting → ValInactive)**: Clear exiting validators first to free up slots and ensure they don't affect top 50 calculation.
 
-2. **T2 (CandTesting evaluation)**: Evaluate VRank before calculating top 50 since passed candidates become eligible for the active set.
+2. **T4 (CandReady → CandTesting or Registered)**: Processed in the same pass as T1 and T2, before top-50 sorting. Newly promoted `CandTesting` nodes do not enter the current epoch's eligible pool — they begin VRank evaluation and may compete for a slot starting next epoch.
 
-3. **T3a (Promote to ValActive)**: Entities in top 50 are promoted. `ValReady` and passed `CandTesting` transition to `ValActive`. `ValPaused` stays paused (recovery is voluntary).
+3. **T2 (CandTesting evaluation)**: Evaluate VRank in the same pass. Passed candidates enter the competition pool; failed candidates return to `Registered`.
 
-4. **T3b (Demote to ValInactive)**: Two cases: (a) `ValActive`, `ValPaused`, `ValReady` below `MinStake` are demoted unconditionally before the top-50 competition; (b) `ValActive`, `ValPaused`, `ValReady`, and passed `CandTesting` that are in the eligible pool but below top 50 are demoted after the competition.
+4. **T3b (below MinStake)**: Nodes with stake below `MinStake` are demoted directly to `ValInactive` during the single pass — no slot limit check. This ensures the eligible pool and subsequent top-50 competition only contain sufficiently staked nodes.
 
-5. **T4a (CandReady → CandTesting)**: Start testing last, after all other transitions are complete, so new testers don't affect the current epoch's calculations.
+5. **T3a (Promote to ValActive)**: After sorting, entities in top 50 are promoted. `ValReady` and passed `CandTesting` transition to `ValActive`. `ValPaused` stays paused (recovery is voluntary).
 
-6. **T4b (CandReady → Registered)**: Demote to Registered if below MinStake.
+6. **T3b (competition demotion)**: Entities in the eligible pool but outside top 50 are demoted to `ValInactive`.
 
 ### Violation Transition
 

--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -483,15 +483,6 @@ VRank manages validator and candidate scoring based on performance metrics as de
 
 - **Upgradeable**: VotingV2, StakingTrackerV3, CLRegistryV2, and other contracts must be deployed as an upgradeable proxy to enable future improvements.
 
-### Governance Parameter Deprecation
-
-After `FORK_BLOCK`, the following governance parameters are deprecated and MUST be rejected for voting:
-
-| Parameter | Reason |
-| --------- | ------ |
-| `governance.addvalidator` | Validator membership is governed by AddressBookV2 state transitions |
-| `governance.removevalidator` | Validator membership is governed by AddressBookV2 state transitions |
-| `istanbul.committeesize` | The committee is derived from the qualified validator set (see KIP-286); a fixed size parameter is no longer applicable |
 
 ## Rationale
 

--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -101,6 +101,14 @@ struct Profile {
     State state;
 }
 
+/// @notice Governance-relevant fields for on-chain voting and GC tracking
+struct GovernanceInfo {
+    address nodeId;
+    address stakingContract;
+    address voterAddress;
+    uint256 gcId;
+}
+
 enum State {
   Unknown,      // 0
   Registered,   // 1
@@ -155,8 +163,11 @@ import {State, BlsPublicKeyInfo, NodeInfo, Profile} from "./types/Node.sol";
 
 interface IAddressBookV2 {
     // ── Errors ──
+    error NotInitializable();
     error OnlySuspender();
     error OnlyConfigurator();
+    error OnlyManager();
+    error OnlyNodeId();
     error InvalidState();
     error SlotsFull();
     error InvalidInput();
@@ -185,6 +196,10 @@ interface IAddressBookV2 {
     event EpochTransitionProcessed(uint256 epochVACount);
     event UintConfigUpdated(uint8 indexed configId, uint256 oldValue, uint256 newValue);
     event AddressConfigUpdated(uint8 indexed configId, address oldValue, address newValue);
+    event ManagerUpdated(address indexed nodeId, address indexed oldManager, address indexed newManager);
+    event RewardAddressUpdated(address indexed nodeId, address indexed oldRewardAddress, address indexed newRewardAddress);
+    event VoterAddressUpdated(address indexed nodeId, address indexed oldVoterAddress, address indexed newVoterAddress);
+    event MetadataUpdated(address indexed nodeId, string newMetadata);
 
     // ── User Functions (called by node manager) ──
 
@@ -250,6 +265,7 @@ interface IAddressBookV2 {
     /// @notice Revoke gcId from a node, setting it back to 0 (called by configurator)
     function revokeGcId(address nodeId) external;
 
+    /// @notice Update protocol configuration parameters (called by configurator)
     function updatePauseTimeout(uint256 newPauseTimeout) external;
     function updateIdleTimeout(uint256 newIdleTimeout) external;
     function updateMaxNodeCount(uint256 newMaxNodeCount) external;
@@ -280,6 +296,8 @@ interface IAddressBookV2 {
     function getMaxValActivePausedCount() external view returns (uint256);
     function getPfsThreshold() external view returns (uint256);
     function getCfsThreshold() external view returns (uint256);
+    function getAllGovernanceInfo() external view returns (GovernanceInfo[] memory);
+    function getAllNodesLength() external view returns (uint256);
 }
 ```
 

--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -274,6 +274,11 @@ interface IAddressBookV2 {
     function updatePfsThreshold(uint256 newPfsThreshold) external;
     function updateCfsThreshold(uint256 newCfsThreshold) external;
 
+    /// @notice Update fund addresses (called by owner)
+    function updateKefAddress(address newKefAddress) external;
+    function updateKifAddress(address newKifAddress) external;
+    function updateKpfAddress(address newKpfAddress) external;
+
     // ── Getters ──
 
     function getSuspender() external view returns (address);
@@ -298,6 +303,8 @@ interface IAddressBookV2 {
     function getCfsThreshold() external view returns (uint256);
     function getAllGovernanceInfo() external view returns (GovernanceInfo[] memory);
     function getAllNodesLength() external view returns (uint256);
+    function isUsedAddress(address addr) external view returns (bool);
+    function getFundAddresses() external view returns (address kefAddress, address kifAddress, address kpfAddress);
 }
 ```
 

--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -476,6 +476,16 @@ VRank manages validator and candidate scoring based on performance metrics as de
 
 - **Upgradeable**: VotingV2, StakingTrackerV3, CLRegistryV2, and other contracts must be deployed as an upgradeable proxy to enable future improvements.
 
+### Governance Parameter Deprecation
+
+After `FORK_BLOCK`, the following governance parameters are deprecated and MUST be rejected for voting:
+
+| Parameter | Reason |
+| --------- | ------ |
+| `governance.addvalidator` | Validator membership is governed by AddressBookV2 state transitions |
+| `governance.removevalidator` | Validator membership is governed by AddressBookV2 state transitions |
+| `istanbul.committeesize` | The committee is derived from the qualified validator set (see KIP-286); a fixed size parameter is no longer applicable |
+
 ## Rationale
 
 ### Removing Embedded Multisig


### PR DESCRIPTION
## Proposed changes

Synchronizes KIP-227, KIP-286, and KIP-290 specifications with the permissionless implementation. Changes were derived by cross-referencing the Go/Solidity implementation against the spec.

**KIP-227**
- Fix terminology: `candidates(N-1)` → `CandTesting(N-1)` for consistency with definition
- Add rule: if block `N+1` is epoch-start, proposer carries `CandTesting(N+1)` instead of `cfReport`

**KIP-286**
- Rewrite epoch transition pseudo-code as a single-pass loop matching the Go implementation (T1, T4, T2, T3b/pool in one pass); update ordering rationale
- Fix ValActive description: remove incorrect "= committee"
- Add **Committee** section: defines `committee(N) = {ValActive} - {Suspended}` with safety fallback, and documents post-HF consensus rules (header.Extra, proposer verification, seal verification, quorum)
- Add **Derived Node Sets** section: documents all 6 node sets (Council, Committee, HeaderGovVoters, CNPeers, RewardEligible, EpochCompetitors) with formulas and API visibility note

**KIP-290**
- Add missing errors: `NotInitializable`, `OnlyManager`, `OnlyNodeId`
- Add missing events: `ManagerUpdated`, `RewardAddressUpdated`, `VoterAddressUpdated`, `MetadataUpdated`
- Add `GovernanceInfo` struct, `getAllGovernanceInfo()`, `getAllNodesLength()`
- Add fund address functions: `updateKefAddress`, `updateKifAddress`, `updateKpfAddress`, `getFundAddresses()`, `isUsedAddress()`
- Clarify config update functions are called by **configurator**, not owner
- Add **Governance Parameter Deprecation** section: `governance.addvalidator`, `governance.removevalidator`, `istanbul.committeesize` deprecated after `FORK_BLOCK`

## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- kaiachain/kaia#905 (permissionless core consensus — basis for Committee/qualified validator rules)
- kaiachain/kaia#904 (MultiCall binding fix)

## Further comments

All changes are implementation-driven: the Go/Solidity code is the ground truth, and these commits bring the spec documents into alignment.