### PR TITLE
kip-290: clarify ABv2 proxy install runs at FORK_BLOCK - 1 finalize

### DIFF
--- a/KIPs/kip-290.md
+++ b/KIPs/kip-290.md
@@ -539,7 +539,7 @@ Despite this compatibility, services MUST adopt AddressBookV2 interfaces to take
 Existing consolidation logic that groups stakes by reward address continues to work correctly; each group simply contains exactly one entry.
 
 AddressBookV2 replaces the existing AddressBook at `0x0000000000000000000000000000000000000400`.
-The address will contain proxy code starting from `FORK_BLOCK`.
+The address MUST contain proxy code starting from block `FORK_BLOCK`; the core client MUST install the ERC1967 proxy at the finalize hook of block `FORK_BLOCK - 1`.
 
 ### CnStakingV4
 


### PR DESCRIPTION
ABv2 proxy is installed at `FORK_BLOCK - 1` finalize, not at `FORK_BLOCK`.
