### PR TITLE
kip-311: add PN compatibility budgets

### DIFF
--- a/KIPs/kip-311.md
+++ b/KIPs/kip-311.md
@@ -50,26 +50,26 @@ Each target map is indexed as `targets[observer type][counterparty type]`.
 The EN-to-EN dial target preserves the pre-fork `DialRatio` semantics.
 It controls how many EN peers an EN actively tries to create through dynamic outbound dialing.
 Accepted EN peers are still bounded by `MaxPhysicalConnections` and inbound capacity; there is no separate EN-to-EN per-type cap.
-CN dial targets are fixed type targets and do not use `DialRatio`.
+Only the EN-to-EN dial target uses `DialRatio`.
 
 #### `discoverTargets`
 
 Target number of entries in the observer's discovery table per counterparty type. `∞` means no cap.
 
-| Observer \ Counterparty | CN  | EN  | BN  |
-| ----------------------- | --- | --- | --- |
-| CN                      | 100 | 1   | 3   |
-| EN                      | 100 | ∞   | 3   |
-| BN                      | 100 | —   | 3   |
+| Observer \ Counterparty | CN  | PN  | EN  | BN  |
+| ----------------------- | --- | --- | --- | --- |
+| CN                      | 100 | —   | 1   | 3   |
+| EN                      | 100 | 2   | ∞   | 3   |
+| BN                      | 100 | —   | —   | 3   |
 
 #### `dialTargets`
 
 Target number of outbound peer connections the observer maintains per counterparty type.
 
-| Observer \ Counterparty | CN  | EN                    | BN  |
-| ----------------------- | --- | --------------------- | --- |
-| CN                      | 100 | 1                     | —   |
-| EN                      | 2   | `maxENToENDialTarget` | —   |
+| Observer \ Counterparty | CN  | PN  | EN                    | BN  |
+| ----------------------- | --- | --- | --------------------- | --- |
+| CN                      | 100 | —   | 1                     | —   |
+| EN                      | 2   | 2   | `maxENToENDialTarget` | —   |
 
 #### `peerTargets`
 
@@ -81,6 +81,7 @@ Per-type admission caps used to preserve scarce connection slots. `∞` means th
 | EN                      | 2   | ∞   | —   |
 
 Finite `peerTargets` protect CNs from excessive EN peers and ENs from excessive CN peers. CN-to-CN and EN-to-EN peers are governed by global physical capacity instead.
+PN is not a separate admission target; PN peers are counted as EN peers for `peerTargets`.
 
 ### Terms
 
@@ -89,7 +90,7 @@ Finite `peerTargets` protect CNs from excessive EN peers and ENs from excessive 
 - **state(n)**: assuming `R(n)`, the `AddressBookV2` state of node `n` as defined in [KIP-286](./kip-286.md).
 - **CNPeers**: `{ n ∈ ℕ | R(n) ∧ state(n) ∈ { CandReady, CandTesting, ValActive, ValReady, ValPaused } }`.
 - **nonCNPeers**: `ℕ \ CNPeers`, equivalent to `{ n ∈ ℕ | ¬R(n) ∨ (R(n) ∧ state(n) ∈ { Registered, ValInactive, ValExiting }) }`.
-- **ConnType**: the peer-type label declared by each side at the Layer 2 RLPx handshake. Post-fork values for new topology: `{ CN, EN, BN }`. `PN` remains a valid legacy value for backwards compatibility with existing deployments, and is treated equivalently to `EN` in all post-fork requirements.
+- **ConnType**: the peer-type label declared by each side at the Layer 2 RLPx handshake. Post-fork values for new topology: `{ CN, EN, BN }`. `PN` remains a valid legacy value for backwards compatibility with existing deployments.
 - **Discovery ping**: UDP ping in the Node Discovery Protocol (as opposed to "RPC call" for on-chain/HTTP queries).
 - **Inbound connection**: a TCP/RLPx connection initiated by the remote node toward the local node.
 - **Outbound connection**: a TCP/RLPx connection initiated by the local node toward the remote node.
@@ -157,7 +158,7 @@ After the permissionless hard fork, the target topology is:
 
 - CNs MUST form a full mesh with all `CNPeers` except themselves.
 - CNs and ENs MUST connect directly; the PN relay layer is removed from the post-fork topology.
-- `ConnType == PN` MUST remain accepted for backwards compatibility and MUST be treated equivalently to `ConnType == EN`.
+- `ConnType == PN` MUST remain accepted for backwards compatibility and, after connection, MUST be served as an EN-equivalent peer.
 - BN is the single bootstrap role for all node types, replacing the pre-fork role-specific bootstrap nodes.
 
 #### R2. Bootstrap Node
@@ -181,7 +182,7 @@ Nodes MUST apply the `discoverTargets` and `dialTargets` parameters defined in t
   When the outbound count falls below target, the node MUST dial additional peers of that type. For EN-to-EN dialing, the target is derived from `MaxPhysicalConnections` and `DialRatio` as defined in Parameters.
 - For CN dynamic outbound dials after the hard fork, CN-typed dial candidates MUST be selected from `CNPeers`.
 - Static outbound dials are operator-requested dials and are not restricted to `CNPeers`.
-- Discovery and dialing accounting MUST treat `ConnType == PN` as `ConnType == EN`.
+- For EN observers, PN and EN target accounting MUST remain type-exact: PN discovery entries and PN outbound peers satisfy only PN targets, while EN discovery entries and EN outbound peers satisfy only EN targets.
 
 #### R4. CN-CN Admission
 
@@ -189,13 +190,13 @@ CN-CN admission is governed by `CNPeers`.
 When admitting a peer connection whose counterparty claims `ConnType == CN`, a CN MUST validate the counterparty's `AddressBookV2` registration and current `CNPeers` membership before Layer 3 message processing begins.
 
 | Connection class | `CNPeers` auth |
-| ---------------- | ---------------- |
-| Trusted peer     | Exempt           |
-| Static outbound  | Exempt           |
-| Static inbound   | Enforced         |
-| Dynamic inbound  | Enforced         |
-| Dynamic outbound | Enforced         |
-| EN, BN           | N/A              |
+| ---------------- | -------------- |
+| Trusted peer     | Exempt         |
+| Static outbound  | Exempt         |
+| Static inbound   | Enforced       |
+| Dynamic inbound  | Enforced       |
+| Dynamic outbound | Enforced       |
+| EN, BN           | N/A            |
 
 For this table:
 
@@ -209,13 +210,13 @@ For this table:
 Nodes MUST apply existing physical-capacity checks and finite `peerTargets` caps.
 This preserves the pre-fork `MaxPhysicalConnections` and inbound capacity semantics, and adds per-type caps only where one connection type must be protected from another.
 
-| Connection class | MaxPhysicalConnections  | Inbound capacity        | `peerTargets`                  |
-| ---------------- | ----------------------- | ----------------------- | ------------------------------ |
-| Trusted peer     | Exempt                  | Exempt                  | Exempt                         |
-| Static outbound  | Exempt                  | N/A                     | Exempt                         |
-| Static inbound   | Enforced unless trusted | Enforced unless trusted | Enforced if finite             |
-| Dynamic inbound  | Enforced unless trusted | Enforced unless trusted | Enforced if finite             |
-| Dynamic outbound | Enforced                | N/A                     | Enforced if finite             |
+| Connection class | MaxPhysicalConnections  | Inbound capacity        | `peerTargets`      |
+| ---------------- | ----------------------- | ----------------------- | ------------------ |
+| Trusted peer     | Exempt                  | Exempt                  | Exempt             |
+| Static outbound  | Exempt                  | N/A                     | Exempt             |
+| Static inbound   | Enforced unless trusted | Enforced unless trusted | Enforced if finite |
+| Dynamic inbound  | Enforced unless trusted | Enforced unless trusted | Enforced if finite |
+| Dynamic outbound | Enforced                | N/A                     | Enforced if finite |
 
 For this table:
 
@@ -260,7 +261,7 @@ Direct CN-EN connectivity is the post-fork sync path for nodes outside the CN me
 
 This KIP changes the existing P2P implementation as follows:
 
-- **R1 Target Network Topology**: CN-CN connectivity changes from the permissioned/static topology to a full mesh over `CNPeers`; PN is retired from the target topology and treated as EN for compatibility.
+- **R1 Target Network Topology**: CN-CN connectivity changes from the permissioned/static topology to a full mesh over `CNPeers`; PN is retired from the target topology.
 - **R2 Bootstrap**: BN discovery changes from optional `AuthorizedNodes` filtering to open discovery with unknown-node rate limiting and unbiased neighbor sampling.
 - **R3 Discovery and Dialing**: Discovery and outbound dial targets become post-fork type targets; CN dynamic outbound CN dials are restricted to `CNPeers`.
 - **R4 CN-CN Admission**: CN admission changes from late peer-type validation during Kaia protocol registration to Layer 2 `CNPeers` authorization before Layer 3 message processing.
@@ -307,6 +308,15 @@ BN establishes no Layer 2 peer connections, so there is no peer-slot budget at B
 R4 enforces `CNPeers` membership at the CN, scoped to `ConnType == CN` only: a node claiming EN self-downgrades into a smaller pool with no consensus traffic (`peerTargets[CN][EN]`), while a node claiming CN must pass `CNPeers` authorization before consuming consensus-facing capacity. This also preserves the legitimate case of a `nonCNPeers` CN (e.g., `ValInactive`) connecting as an EN to sync under R7.
 Distinguishing the malicious CN-as-EN downgrade from a legitimate R7 egress would require peer-history tracking beyond `CNPeers` membership, with no compensating security benefit.
 
+### Why ENs keep a separate PN discovery and dial budget
+
+During mixed-version operation, legacy transaction propagation can still depend on the EN-PN-CN path.
+If PN were collapsed into EN for discovery and dial accounting, ordinary EN peers could fill the EN target and stop a v3.0 EN from discovering or dialing available PNs.
+
+A separate EN-side PN budget reserves PN demand before connection.
+The target of `2` provides redundant PN paths while keeping most default connections for direct CN and EN peers.
+After connection, PN peers still count as EN peers for admission and capacity.
+
 ### Why the existing discovery and dial protocol suffices for CN mesh convergence
 
 A new CN converges into the full mesh within a few minutes using the existing discovery and dial protocol alone. The total time decomposes as:
@@ -327,7 +337,7 @@ This KIP requires the permissionless hard fork.
 Before the fork block, legacy P2P behavior (static `AuthorizedNodes`, permissioned CN set, PN role active) continues unchanged.
 After the fork block:
 
-- The PN role is retired. Existing PN deployments remain operational for backwards compatibility but MAY be deprecated without notice. All post-fork nodes MUST treat `ConnType == PN` equivalently to `ConnType == EN`, so no PN-specific handling is required.
+- The PN role is retired. Existing PN deployments remain operational under the compatibility rules in R1, R3, and R5 but MAY be deprecated without notice.
 - CNs MUST admit peers based on `CNPeers` membership, not a static allowlist.
 - `static-nodes.json` no longer grants inbound CN authorization after the fork. It only configures local static outbound dials, subject to the static outbound exemptions in R4, R5, and R6.
 - Nodes that do not implement R4 will still interoperate as EN peers, but will be rejected on CN-claimed connections.


### PR DESCRIPTION
## Proposed changes

This updates KIP-311 to define explicit PN compatibility budgets during mixed-version operation.
During mixed-version operation, legacy transaction propagation may still depend on the EN-PN-CN path.
If PN were collapsed into EN for discovery and dial accounting, ordinary EN peers could fill the EN target and prevent a v3.0 EN from discovering or dialing available PNs.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [ ] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you proposed and what alternatives you have considered, etc.