### PR TITLE
KIP-311: reserve cross-type slots via own-mesh peer-target caps

### DIFF
--- a/KIPs/kip-311.md
+++ b/KIPs/kip-311.md
@@ -49,7 +49,7 @@ Each target map is indexed as `targets[observer type][counterparty type]`.
 
 The EN-to-EN dial target preserves the pre-fork `DialRatio` semantics.
 It controls how many EN peers an EN actively tries to create through dynamic outbound dialing.
-Accepted EN peers are still bounded by `MaxPhysicalConnections` and inbound capacity; there is no separate EN-to-EN per-type cap.
+Accepted EN peers are bounded by `MaxPhysicalConnections`, inbound capacity, and the `peerTargets[EN][EN] = M − peerTargets[EN][CN]` cap that reserves slots for CN peers.
 Only the EN-to-EN dial target uses `DialRatio`.
 
 #### `discoverTargets`
@@ -73,15 +73,16 @@ Target number of outbound peer connections the observer maintains per counterpar
 
 #### `peerTargets`
 
-Per-type admission caps used to preserve scarce connection slots. `∞` means there is no additional per-type cap beyond `MaxPhysicalConnections` and inbound capacity.
+Per-type admission caps used to preserve scarce connection slots. `M` is `MaxPhysicalConnections`.
 
-| Observer \ Counterparty | CN  | EN  | BN  |
-| ----------------------- | --- | --- | --- |
-| CN                      | ∞   | 3   | —   |
-| EN                      | 2   | ∞   | —   |
+| Observer \ Counterparty | CN      | EN      | BN  |
+| ----------------------- | ------- | ------- | --- |
+| CN                      | `M − 3` | 3       | —   |
+| EN                      | 2       | `M − 2` | —   |
 
-Finite `peerTargets` protect CNs from excessive EN peers and ENs from excessive CN peers. CN-to-CN and EN-to-EN peers are governed by global physical capacity instead.
+The cross-type caps protect a CN from excessive EN peers (`CN→EN = 3`) and an EN from excessive CN peers (`EN→CN = 2`); these reserved counts are the slots kept for the CN↔EN link. The own-type mesh caps are derived as `M` minus that reservation, so a node's own-type mesh cannot consume every connection and starve the cross-type link: a CN always keeps at least `peerTargets[CN][EN]` slots for ENs, and an EN always keeps at least `peerTargets[EN][CN]` slots for CNs.
 PN is not a separate admission target; PN peers are counted as EN peers for `peerTargets`.
+The cross-type reservation values are RECOMMENDED defaults; an operator MAY override them locally, since each node's reservation governs only its own slot allocation and needs no network-wide agreement.
 
 ### Terms
 
@@ -220,7 +221,7 @@ This preserves the pre-fork `MaxPhysicalConnections` and inbound capacity semant
 
 For this table:
 
-- `peerTargets` is an additional per-type admission cap. `∞` means no per-type cap beyond `MaxPhysicalConnections` and inbound capacity.
+- `peerTargets` is a per-type admission cap. The cross-type cap bounds the other type, and the own-type mesh cap (`M` minus the cross-type reservation) keeps the own mesh from starving the cross-type link.
 - A node MUST NOT accept a non-exempt peer connection that would cause its total peer count for type `X` to exceed a finite `peerTargets[observer][X]`.
 - `ConnType == PN` MUST be counted as `ConnType == EN` for `peerTargets`.
 - Exempt peers MUST still count toward observed peer totals and dial scheduling.
@@ -280,7 +281,7 @@ This KIP changes the existing P2P implementation as follows:
 5. `NodeId` is immutable.
    Key rotation requires a full `deleteNode()` followed by re-onboarding.
 6. `|CNPeers| ≤ MaxNodeCount` as defined in [KIP-286](./kip-286.md).
-   CN full mesh capacity is provided by `MaxPhysicalConnections`; `peerTargets[CN][CN] = ∞` means there is no additional CN-to-CN per-type cap beyond global physical capacity.
+   CN full mesh capacity is provided by `MaxPhysicalConnections`, sized to at least `MaxNodeCount + peerTargets[CN][EN]`; the `peerTargets[CN][CN] = M − peerTargets[CN][EN]` cap then reserves the remaining slots for EN peers regardless of how `MaxPhysicalConnections` is configured.
 
 ## Rationale
 


### PR DESCRIPTION
## Proposed changes

Own-mesh `peerTargets` (CN↔CN, EN↔EN) change from `∞` to `M − cross-type reservation`, so a node's own-type mesh can no longer consume every connection slot and starve the CN↔EN link.

- **Before**: own-mesh `∞`; the CN↔EN reservation was *implicit*, relying on operators sizing `M ≥ MaxNodeCount + peerTargets[CN][EN]`.
- **After**: own-mesh capped at `M − reservation`, so cross-type slots are *explicitly* reserved **regardless of how `MaxPhysicalConnections` is configured**. In the recommended config the cap never binds (identical to `∞`); it only adds a guaranteed floor when `maxconnections` is undersized.
- Cross-type reservation values are documented as operator-configurable defaults.



## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [ ] Used the suggested template
- [ ] I have read the CLA and signed by comment
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

-
