### PR TITLE
kip-311: clarify a peer counts once regardless of transport channels

### DIFF
--- a/KIPs/kip-311.md
+++ b/KIPs/kip-311.md
@@ -97,7 +97,7 @@ The cross-type reservation values are RECOMMENDED defaults; an operator MAY over
 - **Outbound connection**: a TCP/RLPx connection initiated by the local node toward the remote node.
 - **Trusted peer**: a peer explicitly configured by the local operator as trusted, for example through a `trusted-nodes.json` file. Trusted peer configuration grants bidirectional operator trust for inbound and outbound connections.
 - **Static peer**: a peer explicitly configured by the local operator as static, for example through a `static-nodes.json` file. Static peer configuration is a local outbound dialing preference and does not grant inbound authorization.
-- **MaxPhysicalConnections**: the node's configured maximum total physical peer connections, inbound and outbound combined.
+- **MaxPhysicalConnections**: the node's configured maximum total physical peer connections, inbound and outbound combined. A peer counts once toward this limit regardless of how many transport connections (channels) it opens; e.g. a multi-channel peer using several sockets is still a single peer.
 - **DialRatio**: the node's configured ratio used to derive EN-to-EN dynamic dialing and EN inbound capacity. If unset or zero, it defaults to `3`.
 - **Inbound capacity**: the node's limit on inbound physical peer connections. For ENs and legacy PNs, this is `MaxPhysicalConnections - ⌊MaxPhysicalConnections / DialRatio⌋`; for CNs and BNs, this is `MaxPhysicalConnections`.
 


### PR DESCRIPTION
## Proposed changes

KIP-311 defines `MaxPhysicalConnections` / inbound capacity as "physical peer
connections", which can be misread as sockets. This adds one sentence clarifying that a
multi-channel peer counts once toward the limit, keeping the budgets per-peer.
Wording-only / non-normative — no spec or behavior change.

Pairs with kaiachain/kaia#965, which aligns inbound admission to this peer-based counting.

## Types of changes

- [ ] Bugfix
- [ ] KIP Proposal
- [x] KIP Improvement

## Checklist

- [x] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribution
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- kaiachain/kaia#965

## Further comments

