### PR TITLE
KIP-227: clarify threshold semantics as inclusive

### DIFF
--- a/KIPs/kip-227.md
+++ b/KIPs/kip-227.md
@@ -43,8 +43,8 @@ The framework promotes consistent uptime and reliability. Validators have an inc
 | `CANDIDATE_MSG_TIMEOUT`     | Protocol parameter (milliseconds). Default = 500ms.                                                                                                                                        |
 | `EPOCH_LENGTH`              | 86,400 blocks (approximately 1 day, assuming 1-second block time)                                                                                                                          |
 | `MAX_BYZANTINE_NODES` (`F`) | Calculated as `F = floor(len(proposerSet) / 3)`, where `proposerSet` is the set of distinct proposers observed in the current epoch up to and including the block at which CFS is computed |
-| `PFS_THRESHOLD`             | 2 (max proposal failures per epoch)                                                                                                                                                        |
-| `CFS_THRESHOLD`             | 300 (max candidate failures per epoch)                                                                                                                                                     |
+| `PFS_THRESHOLD`             | 2 (reaching the threshold means not qualified)                                                                                                                                             |
+| `CFS_THRESHOLD`             | 300 (reaching the threshold means not qualified)                                                                                                                                           |
 
 ### Data Structures and Protocol Primitives
 
@@ -239,13 +239,13 @@ _Note: Each `cfReport(N)` is in the header of block `N` and reports on target bl
 
 A node must meet the following stability requirements to participate in consensus:
 
-- **Block proposal participation**: At most `PFS_THRESHOLD` proposal failures per epoch.
+- **Block proposal participation**: Fewer than `PFS_THRESHOLD` proposal failures per epoch.
 - **Downtime**: Less than 0.5% downtime per epoch (fewer than 432 blocks missed).
 
 Violations:
 
-- a validator exceeding `PFS_THRESHOLD` in an epoch is classified as not qualified.
-- a candidate exceeding `CFS_THRESHOLD` in an epoch is classified as not qualified.
+- a validator whose PFS reaches `PFS_THRESHOLD` in an epoch (`PFS >= PFS_THRESHOLD`) is classified as not qualified.
+- a candidate whose CFS reaches `CFS_THRESHOLD` in an epoch (`CFS >= CFS_THRESHOLD`) is classified as not qualified.
 
 The handling of not-qualified nodes is specified in [KIP-286](https://kips.kaia.io/KIPs/kip-286).
 


### PR DESCRIPTION
PFS_THRESHOLD/CFS_THRESHOLD wording used "max failures" / "at most" / "exceeding", implying a node stays qualified at the threshold value. The reference implementation disqualifies at score >= THRESHOLD. Reword the parameter table and score-threshold section so reaching the threshold means not qualified, matching the code.

## Proposed changes

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] KIP Proposal
- [ ] KIP Improvement

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] Used the suggested template: https://github.com/kaiachain/KIPs/blob/main/kip-template.md
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribution
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you proposed and what alternatives you have considered, etc.